### PR TITLE
Make Game an abstract class and create METGame

### DIFF
--- a/src/MEU.GV4.Data/Models/Game.cs
+++ b/src/MEU.GV4.Data/Models/Game.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// The Game class is the top-level container for all game-related data.
 /// </summary>
-public class Game
+public abstract class Game
 {
     public string? Title { get; set; }
     public string? Website { get; set; }

--- a/src/MEU.GV4.Data/Models/METClassic/METGame.cs
+++ b/src/MEU.GV4.Data/Models/METClassic/METGame.cs
@@ -1,0 +1,5 @@
+﻿namespace MEU.GV4.Data.Models.METClassic;
+
+public class METGame : Game
+{
+}

--- a/src/MEU.GV4.Data/Providers/GrapevineLegacyXMLReader.cs
+++ b/src/MEU.GV4.Data/Providers/GrapevineLegacyXMLReader.cs
@@ -29,7 +29,7 @@ public class GrapevineLegacyXMLReader
             throw new GrapevineProviderException(INVALID_GRAPEVINE_FILE);
         }
 
-        var gameData = new Game()
+        var gameData = new METGame()
         {
             Title = XmlHelper.GetAttribute(root, "chronicle"),
             Website = XmlHelper.GetAttribute(root, "website"),

--- a/tests/MEU.GV4.Data.Tests/Providers/GrapevineLegacyXMLReaderTetsts.cs
+++ b/tests/MEU.GV4.Data.Tests/Providers/GrapevineLegacyXMLReaderTetsts.cs
@@ -10,7 +10,7 @@ public class GrapevineLegacyXMLReaderTetsts
     [Fact(DisplayName = "Can Load Basic Game Data")]
     public void CanLoadBasicGameData()
     {
-        var expected = new Game()
+        var expected = new METGame()
         {
             Title = "TEST CHRONICLE",
             Website = "https://example.com",
@@ -47,7 +47,7 @@ public class GrapevineLegacyXMLReaderTetsts
     [Fact(DisplayName = "Can Load With Empty Values")]
     public void CanLoadWithEmptyValues()
     {
-        var expected = new Game()
+        var expected = new METGame()
         {
             Title = "TEST CHRONICLE",
             Website = null,
@@ -167,7 +167,7 @@ public class GrapevineLegacyXMLReaderTetsts
     [Fact(DisplayName = "Can Load PlayerData")]
     public void CanLoadPlayerData()
     {
-        var expected = new Game()
+        var expected = new METGame()
         {
             Title = "TEST CHRONICLE",
             Players =
@@ -302,7 +302,7 @@ public class GrapevineLegacyXMLReaderTetsts
     [Fact(DisplayName = "Can mark IsNPC as true when set in xml as yes")]
     public void CanMarkNPCWhenSetInXml()
     {
-        var expected = new Game()
+        var expected = new METGame()
         {
             Title = "TEST CHRONICLE",
             Players = [],


### PR DESCRIPTION
This allows items that may be specific only to classic MET games to be isolated away from other game implementations.